### PR TITLE
Switch to busybox:latest base image to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ RUN \
   && git rev-parse HEAD \
   && mvn clean package
 
-FROM eclipse-temurin:11.0.13_8-jre-alpine
+FROM busybox:latest
 COPY --from=build /jmx_exporter/jmx_prometheus_javaagent/target/jmx_prometheus_javaagent-*.jar /opt/jmx_exporter/
 RUN ln -s /opt/jmx_exporter/jmx_prometheus_javaagent-*.jar /jmx_prometheus_javaagent.jar
-
-CMD ["/bin/bash"]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Change the base docker image to `busybox`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Using `busybox` results in a much smaller image (134 MB -> 2 MB). This image just stores the jmx java agent JAR file and is used in initcontainers to copy the JAR to containers that need the JAR.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
