### PR TITLE
Replaced GHA `set-output` with `GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
           if_false: latest
       - name: Determine image tag
         id: imagetag
-        run: echo "::set-output name=value::${TAG_OR_BRANCH##*/}"
+        run: echo "value=${TAG_OR_BRANCH##*/}" >> $GITHUB_OUTPUT
         env:
           TAG_OR_BRANCH: ${{ steps.refortag.outputs.value }}
 


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no|
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | - |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Replaced `::set-output` with `>> $GITHUB_OUTPUT`

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Deprecated, will be removed in 2023-05-31.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Details: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

Tested [in another PR](https://github.com/banzaicloud/koperator/pull/906/files#diff-dce4cd1ca1dc3e5849de0fd3f3c7b132ad537e4ba79ba191f5de4330484b214bR39), worked well.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- ~Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)~
- ~Logging code meets the guideline~
- ~User guide and development docs updated (if needed)~
