### PR TITLE
fixes : add arm64 platform

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
       - "[0-9].[0-9]+.[0-9]+*"
   # pull_request:
 env:
-  PLATFORMS: linux/amd64
+  PLATFORMS: linux/amd64,linux/arm64
 jobs:
   docker:
     name: Docker
@@ -46,7 +46,7 @@ jobs:
       - name: Build jmx-exporter
         uses: docker/build-push-action@v2
         with:
-          tags: ghcr.io/banzaicloud/jmx-javaagent:${{ steps.imagetag.outputs.value }}
+          tags: ghcr.io/${{ github.repository_owner }}/jmx-javaagent:${{ steps.imagetag.outputs.value }}
           file: Dockerfile
           platforms: ${{ env.PLATFORMS }}
           push: true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Support the docker image to arm64 platform.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The kafka-operator create kafkaCluster not support arm64 platform

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

action job:  https://github.com/cuisongliu/koperator-docker-jmx-exporter/actions/runs/6518183532

image manfiest:  https://explore.ggcr.dev/?image=ghcr.io%2Fcuisongliu%2Fjmx-javaagent:0.16.1a

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~~User guide and development docs updated (if needed)~~
- ~~Related Helm chart(s) updated (if needed)~~

### To Do
<!-- (Please remove this section if you don't need it.) -->
- ~~If the PR is not complete but you want to discuss the approach, list what remains to be done here~~
